### PR TITLE
Update utils.bash to use the new release URL format

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -37,7 +37,7 @@ download_release() {
   version="$1"
   filename="$2"
 
-  url="$GH_REPO/releases/download/v${version}/viddy_$(uname -s)_x86_64.tar.gz"
+  url="$GH_REPO/releases/download/v${version}/viddy-v${version}-$(uname -s | tr '[:upper:]' '[:lower:]')-x86_64.tar.gz"
 
   echo "* Downloading $TOOL_NAME release $version..."
   curl "${curl_opts[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -37,7 +37,7 @@ download_release() {
   version="$1"
   filename="$2"
 
-  url="$GH_REPO/releases/download/v${version}/viddy-v${version}-$(uname -s | tr '[:upper:]' '[:lower:]')-x86_64.tar.gz"
+  url="$GH_REPO/releases/download/v${version}/viddy-v${version}-$(uname -s | tr '[:upper:]' '[:lower:]' | sed 's/darwin/macos/')-x86_64.tar.gz"
 
   echo "* Downloading $TOOL_NAME release $version..."
   curl "${curl_opts[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"


### PR DESCRIPTION
This change adapts the script to the new URL format of the viddy releases:

<img width="953" alt="image" src="https://github.com/user-attachments/assets/00722beb-652d-424d-a6e8-51e362ed6419">

| Scenario | URL |
|--------|--------|
| Before | https://github.com/sachaos/viddy/releases/download/v1.1.2/viddy_Linux_x86_64.tar.gz |
| After | https://github.com/sachaos/viddy/releases/download/v1.1.2/viddy-v1.1.2-linux-x86_64.tar.gz | 